### PR TITLE
external read/write macros from d-a-v Esp8266 branch

### DIFF
--- a/examples/tgunzip/makefile
+++ b/examples/tgunzip/makefile
@@ -14,6 +14,7 @@ objects = tgunzip.o
 libs    = ../../lib/libtinf.a
 
 COPT    = -Os
+COPT    += -DNO_DICT=1
 CFLAGS  = -Wall -I../../src $(COPT)
 LDFLAGS = $(CFLAGS) -s -Wl,-Map,ld.map
 

--- a/examples/tgunzip/makefile
+++ b/examples/tgunzip/makefile
@@ -14,7 +14,7 @@ objects = tgunzip.o
 libs    = ../../lib/libtinf.a
 
 COPT    = -Os
-COPT    += -DNO_DICT=1
+COPT    += -DNO_DICT=1 -DNO_CB=1
 CFLAGS  = -Wall -I../../src $(COPT)
 LDFLAGS = $(CFLAGS) -s -Wl,-Map,ld.map
 

--- a/examples/tgunzip/tgunzip.c
+++ b/examples/tgunzip/tgunzip.c
@@ -124,7 +124,9 @@ int main(int argc, char *argv[])
     /* all 3 fields below must be initialized by user */
     d.source = source;
     d.source_limit = source + len - 4;
+#if !NO_CB
     d.source_read_cb = NULL;
+#endif
 
     res = uzlib_gzip_parse_header(&d);
     if (res != TINF_OK) {

--- a/examples/tgunzip/tgunzip.c
+++ b/examples/tgunzip/tgunzip.c
@@ -114,8 +114,12 @@ int main(int argc, char *argv[])
     /* -- decompress data -- */
 
     struct uzlib_uncomp d;
+#if NO_DICT
+    uzlib_uncompress_init(&d);
+#else
 //    uzlib_uncompress_init(&d, malloc(32768), 32768);
     uzlib_uncompress_init(&d, NULL, 0);
+#endif
 
     /* all 3 fields below must be initialized by user */
     d.source = source;

--- a/examples/uz2flash/TEST
+++ b/examples/uz2flash/TEST
@@ -1,0 +1,1 @@
+(cd ../..; make clean; make); valgrind ./uzf 0c 0 && diff 0 0u && echo ok

--- a/examples/uz2flash/TEST
+++ b/examples/uz2flash/TEST
@@ -1,1 +1,7 @@
+#!/bin/sh
+
+if [ ! -r 0c ]; then
+    (cd ../..; tar cf - .) > 0u
+    gzip -c9 < 0u > 0c
+fi
 (make clean; make); valgrind ./uzf 0c 0 && diff 0 0u && echo ok

--- a/examples/uz2flash/TEST
+++ b/examples/uz2flash/TEST
@@ -1,1 +1,1 @@
-(cd ../..; make clean; make); valgrind ./uzf 0c 0 && diff 0 0u && echo ok
+(make clean; make); valgrind ./uzf 0c 0 && diff 0 0u && echo ok

--- a/examples/uz2flash/makefile
+++ b/examples/uz2flash/makefile
@@ -12,10 +12,11 @@
 target  = uzf
 objects = uzf.o
 
-COPT    = -O0 -g
+COPT    = -g
 COPT    += -DNO_DICT=1 -DNO_CB=1
-CFLAGS  = -Wall -I../../src $(COPT)
-LDFLAGS = $(CFLAGS) -s -Wl,-Map,ld.map
+CFLAGS  = -Wall -Wextra -Werror -I../../src $(COPT)
+#LDFLAGS = $(CFLAGS) -s -Wl,-Map,ld.map
+LDFLAGS = $(CFLAGS)
 
 .PHONY: all clean
 

--- a/examples/uz2flash/makefile
+++ b/examples/uz2flash/makefile
@@ -1,0 +1,31 @@
+##
+## tgunzip  -  gzip decompressor example
+##
+## GCC makefile (Linux, FreeBSD, BeOS and QNX)
+##
+## Copyright (c) 2003 by Joergen Ibsen / Jibz
+## All Rights Reserved
+##
+## http://www.ibsensoftware.com/
+##
+
+target  = uzf
+objects = uzf.o
+
+COPT    = -O0 -g
+COPT    += -DNO_DICT=1 -DNO_CB=1
+CFLAGS  = -Wall -I../../src $(COPT)
+LDFLAGS = $(CFLAGS) -s -Wl,-Map,ld.map
+
+.PHONY: all clean
+
+all: $(target)
+
+$(target): $(objects) $(libs)
+	$(CC) $(LDFLAGS) -o $@ $^ $(libs)
+
+%.o : %.c
+	$(CC) $(CFLAGS) -c $<
+
+clean:
+	$(RM) $(objects) $(target)

--- a/examples/uz2flash/uzf.c
+++ b/examples/uz2flash/uzf.c
@@ -45,7 +45,10 @@
     Flash constraints are:
     - only 32 bit access
     - wear leveling: reduce the number of write on flash blocks (512 bytes in this example)
-    - not much ram (dictionary disabled: uncompressed data = flash are used for dictionary)
+    - not much ram (specific dictionary code is disabled:
+                    then full-dest-in-memory is forced, inflated data are
+                    fetched from freshly written flash memory
+                    using ALIGN_READ and ALIGN_WRITE macros)
 
     This example uncompresses data to a temporary 512 bytes block, and move
     it to flash everytime it is full.

--- a/examples/uz2flash/uzf.c
+++ b/examples/uz2flash/uzf.c
@@ -1,0 +1,164 @@
+/*
+ * tgunzip  -  gzip decompressor example
+ *
+ * Copyright (c) 2003 by Joergen Ibsen / Jibz
+ * All Rights Reserved
+ *
+ * http://www.ibsensoftware.com/
+ *
+ * Copyright (c) 2014-2016 by Paul Sokolovsky
+ *
+ * This software is provided 'as-is', without any express
+ * or implied warranty.  In no event will the authors be
+ * held liable for any damages arising from the use of
+ * this software.
+ *
+ * Permission is granted to anyone to use this software
+ * for any purpose, including commercial applications,
+ * and to alter it and redistribute it freely, subject to
+ * the following restrictions:
+ *
+ * 1. The origin of this software must not be
+ *    misrepresented; you must not claim that you
+ *    wrote the original software. If you use this
+ *    software in a product, an acknowledgment in
+ *    the product documentation would be appreciated
+ *    but is not required.
+ *
+ * 2. Altered source versions must be plainly marked
+ *    as such, and must not be misrepresented as
+ *    being the original software.
+ *
+ * 3. This notice may not be removed or altered from
+ *    any source distribution.
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+
+#include "adler32.c"
+#include "crc32.c"
+
+#include "tinflate.c"
+#include "tinfgzip.c"
+#include "tinfzlib.c"
+
+/* produce decompressed output in chunks of this size */
+/* defauly is to decompress byte by byte; can be any other length */
+#define OUT_CHUNK_SIZE 512
+
+void exit_error(const char *what)
+{
+   printf("ERROR: %s\n", what);
+   exit(1);
+}
+
+int main(int argc, char *argv[])
+{
+    FILE *fin, *fout;
+    unsigned int len, dlen, outlen;
+    const unsigned char *source;
+    unsigned char *dest;
+    int res;
+
+    printf("tgunzip - example from the tiny inflate library (www.ibsensoftware.com)\n\n");
+
+    if (argc < 3)
+    {
+       printf(
+          "Syntax: tgunzip <source> <destination>\n\n"
+          "Both input and output are kept in memory, so do not use this on huge files.\n");
+
+       return 1;
+    }
+
+    uzlib_init();
+
+    /* -- open files -- */
+
+    if ((fin = fopen(argv[1], "rb")) == NULL) exit_error("source file");
+
+    if ((fout = fopen(argv[2], "wb")) == NULL) exit_error("destination file");
+
+    /* -- read source -- */
+
+    fseek(fin, 0, SEEK_END);
+
+    len = ftell(fin);
+
+    fseek(fin, 0, SEEK_SET);
+
+    source = (unsigned char *)malloc(len);
+
+    if (source == NULL) exit_error("memory");
+
+    if (fread((unsigned char*)source, 1, len, fin) != len) exit_error("read");
+
+    fclose(fin);
+
+    if (len < 4) exit_error("file too small");
+
+    /* -- get decompressed length -- */
+
+    dlen =            source[len - 1];
+    dlen = 256*dlen + source[len - 2];
+    dlen = 256*dlen + source[len - 3];
+    dlen = 256*dlen + source[len - 4];
+
+    outlen = dlen;
+
+    /* there can be mismatch between length in the trailer and actual
+       data stream; to avoid buffer overruns on overlong streams, reserve
+       one extra byte */
+    dlen++;
+
+    dest = (unsigned char *)malloc(dlen);
+
+    if (dest == NULL) exit_error("memory");
+    
+#if !NO_DICT || !NO_CB
+#error
+#endif
+
+    /* -- decompress data -- */
+
+    struct uzlib_uncomp d;
+    uzlib_uncompress_init(&d);
+
+    /* all 2 fields below must be initialized by user */
+    d.source = source;
+    d.source_limit = source + len - 4;
+
+    res = uzlib_gzip_parse_header(&d);
+    if (res != TINF_OK) {
+        printf("Error parsing header: %d\n", res);
+        exit(1);
+    }
+
+    d.dest_start = d.dest = dest;
+
+    while (dlen) {
+        unsigned int chunk_len = dlen < OUT_CHUNK_SIZE ? dlen : OUT_CHUNK_SIZE;
+        d.dest_limit = d.dest + chunk_len;
+        res = uzlib_uncompress(&d);
+        dlen -= chunk_len;
+        if (res != TINF_OK) {
+            break;
+        }
+    }
+
+    if (res != TINF_DONE) {
+        printf("Error during decompression: %d\n", res);
+        exit(-res);
+    }
+
+    printf("decompressed %lu bytes\n", d.dest - dest);
+
+    /* -- write output -- */
+
+    fwrite(dest, 1, outlen, fout);
+
+    fclose(fout);
+
+    return 0;
+}

--- a/examples/uz2flash/uzf.c
+++ b/examples/uz2flash/uzf.c
@@ -38,6 +38,26 @@
 #include <assert.h>
 #include <string.h>
 
+/*
+
+    This example is a use case for esp8266 where all compressed data is accessible from flash
+    and are inflated to flash (like in OTA operations).
+    Flash constraints are:
+    - only 32 bit access
+    - wear leveling: reduce the number of write on flash blocks (512 bytes in this example)
+    - not much ram (dictionary disabled: uncompressed data = flash are used for dictionary)
+
+    This example uncompresses data to a temporary 512 bytes block, and move
+    it to flash everytime it is full.
+
+    The align_read() function goes get data from already inflated data from
+    flash when they are outside from the 512bytes temp buffer.
+
+*/
+
+
+#define NO_DICT 1
+#define NO_CB 1
 
 #define TMPSZ 512
 unsigned char tmp [TMPSZ];

--- a/src/makefile
+++ b/src/makefile
@@ -14,7 +14,7 @@ objects = tinflate.o tinfgzip.o tinfzlib.o adler32.o crc32.o \
     defl_static.o genlz77.o
 
 COPT    = -Os
-COPT    += -DNO_DICT=1
+COPT    += -DNO_DICT=1 -DNO_CB=1
 CFLAGS  = -Wall $(COPT)
 LDFLAGS = $(CFLAGS) -s
 

--- a/src/makefile
+++ b/src/makefile
@@ -14,6 +14,7 @@ objects = tinflate.o tinfgzip.o tinfzlib.o adler32.o crc32.o \
     defl_static.o genlz77.o
 
 COPT    = -Os
+COPT    += -DNO_DICT=1
 CFLAGS  = -Wall $(COPT)
 LDFLAGS = $(CFLAGS) -s
 

--- a/src/tinfgzip.c
+++ b/src/tinfgzip.c
@@ -46,7 +46,7 @@ uint16_t tinf_get_uint16(TINF_DATA *d);
 
 void tinf_skip_bytes(TINF_DATA *d, int num)
 {
-    while (num--) uzlib_get_byte(d);
+    while (num--) (void)uzlib_get_byte(d);
 }
 
 uint16_t tinf_get_uint16(TINF_DATA *d)

--- a/src/tinflate.c
+++ b/src/tinflate.c
@@ -195,7 +195,7 @@ unsigned char uzlib_get_byte(TINF_DATA *d)
     /* If end of source buffer is not reached, return next byte from source
        buffer. */
     if (d->source < d->source_limit) {
-        return *d->source++;
+        return ALIGN_READ(d->source++);
     }
 
     /* Otherwise if there's callback and we haven't seen EOF yet, try to
@@ -486,7 +486,8 @@ static int tinf_inflate_block_data(TINF_DATA *d, TINF_TREE *lt, TINF_TREE *dt)
     } else
 #endif // !NO_DICT
     {
-        d->dest[0] = d->dest[d->lzOff];
+        //d->dest[0] = d->dest[d->lzOff];
+        ALIGN_WRITE(d->dest, d->dest[d->lzOff]);
         d->dest++;
     }
     d->curlen--;

--- a/src/tinflate.c
+++ b/src/tinflate.c
@@ -467,7 +467,7 @@ static int tinf_inflate_block_data(TINF_DATA *d, TINF_TREE *lt, TINF_TREE *dt)
 #endif // !NO_DICT
         {
             /* catch trying to point before the start of dest buffer */
-            if (offs > d->dest - d->destStart) {
+            if ((long)offs > d->dest - d->destStart) {
                 return TINF_DATA_ERROR;
             }
             d->lzOff = -offs;

--- a/src/tinflate.c
+++ b/src/tinflate.c
@@ -189,6 +189,7 @@ static void tinf_build_tree(TINF_TREE *t, const unsigned char *lengths, unsigned
  * -- decode functions -- *
  * ---------------------- */
 
+#if !NO_CB
 unsigned char uzlib_get_byte(TINF_DATA *d)
 {
     /* If end of source buffer is not reached, return next byte from source
@@ -197,7 +198,6 @@ unsigned char uzlib_get_byte(TINF_DATA *d)
         return *d->source++;
     }
 
-#if !NO_CB
     /* Otherwise if there's callback and we haven't seen EOF yet, try to
        read next byte using it. (Note: the callback can also update ->source
        and ->source_limit). */
@@ -207,7 +207,6 @@ unsigned char uzlib_get_byte(TINF_DATA *d)
             return (unsigned char)val;
         }
     }
-#endif
 
     /* Otherwise, we hit EOF (either from ->readSource() or from exhaustion
        of the buffer), and it will be "sticky", i.e. further calls to this
@@ -216,6 +215,7 @@ unsigned char uzlib_get_byte(TINF_DATA *d)
 
     return 0;
 }
+#endif // NO_CB == 0
 
 uint32_t tinf_get_le_uint32(TINF_DATA *d)
 {

--- a/src/tinflate.c
+++ b/src/tinflate.c
@@ -197,6 +197,7 @@ unsigned char uzlib_get_byte(TINF_DATA *d)
         return *d->source++;
     }
 
+#if !NO_CB
     /* Otherwise if there's callback and we haven't seen EOF yet, try to
        read next byte using it. (Note: the callback can also update ->source
        and ->source_limit). */
@@ -206,6 +207,7 @@ unsigned char uzlib_get_byte(TINF_DATA *d)
             return (unsigned char)val;
         }
     }
+#endif
 
     /* Otherwise, we hit EOF (either from ->readSource() or from exhaustion
        of the buffer), and it will be "sticky", i.e. further calls to this

--- a/src/tinflate.c
+++ b/src/tinflate.c
@@ -195,7 +195,8 @@ unsigned char uzlib_get_byte(TINF_DATA *d)
     /* If end of source buffer is not reached, return next byte from source
        buffer. */
     if (d->source < d->source_limit) {
-        return ALIGN_READ(d->source++);
+        //return ALIGN_READ(d->source++);
+        return ALIGN_READ_INC(d->source);
     }
 
     /* Otherwise if there's callback and we haven't seen EOF yet, try to
@@ -487,7 +488,7 @@ static int tinf_inflate_block_data(TINF_DATA *d, TINF_TREE *lt, TINF_TREE *dt)
 #endif // !NO_DICT
     {
         //d->dest[0] = d->dest[d->lzOff];
-        ALIGN_WRITE(d->dest, d->dest[d->lzOff]);
+        ALIGN_WRITE(d->dest, ALIGN_READ(d->dest + d->lzOff));
         d->dest++;
     }
     d->curlen--;

--- a/src/uzlib.h
+++ b/src/uzlib.h
@@ -118,7 +118,11 @@ struct uzlib_uncomp {
 #endif // NO_DICT == 0
 #endif // !defined(TINF_PUT)
 
+#if NO_CB // NO_CB != 0
+#define uzlib_get_byte(d) (*(d)->source++)
+#else
 unsigned char TINFCC uzlib_get_byte(TINF_DATA *d);
+#endif
 
 /* Decompression API */
 

--- a/src/uzlib.h
+++ b/src/uzlib.h
@@ -89,9 +89,11 @@ struct uzlib_uncomp {
     int bfinal;
     unsigned int curlen;
     int lzOff;
+#if !NO_DICT
     unsigned char *dict_ring;
     unsigned int dict_size;
     unsigned int dict_idx;
+#endif
 
     TINF_TREE ltree; /* dynamic length/symbol tree */
     TINF_TREE dtree; /* dynamic distance tree */
@@ -99,18 +101,29 @@ struct uzlib_uncomp {
 
 #include "tinf_compat.h"
 
+#if NO_DICT
+#define TINF_PUT(d, c) \
+    { \
+        *d->dest++ = c; \
+    }
+#else
 #define TINF_PUT(d, c) \
     { \
         *d->dest++ = c; \
         if (d->dict_ring) { d->dict_ring[d->dict_idx++] = c; if (d->dict_idx == d->dict_size) d->dict_idx = 0; } \
     }
+#endif
 
 unsigned char TINFCC uzlib_get_byte(TINF_DATA *d);
 
 /* Decompression API */
 
 void TINFCC uzlib_init(void);
+#if NO_DICT
+void TINFCC uzlib_uncompress_init(TINF_DATA *d);
+#else
 void TINFCC uzlib_uncompress_init(TINF_DATA *d, void *dict, unsigned int dictLen);
+#endif
 int  TINFCC uzlib_uncompress(TINF_DATA *d);
 int  TINFCC uzlib_uncompress_chksum(TINF_DATA *d);
 

--- a/src/uzlib.h
+++ b/src/uzlib.h
@@ -103,23 +103,33 @@ struct uzlib_uncomp {
 
 #include "tinf_compat.h"
 
+#ifndef ALIGN_READ
+#define ALIGN_READ(x) (*(x))
+#endif
+
+#ifndef ALIGN_WRITE
+#define ALIGN_WRITE(x,y) do { (*x) = (y); } while (0)
+#endif
+
 #ifndef TINF_PUT
-#if NO_DICT // NO_DICT != 0
+#if NO_DICT
 #define TINF_PUT(d, c) \
     { \
-        *d->dest++ = c; \
+        ALIGN_WRITE(d->dest, c); \
+        d->dest++; \
     }
 #else // NO_DICT == 0
 #define TINF_PUT(d, c) \
     { \
-        *d->dest++ = c; \
+        ALIGN_WRITE(d->dest, c); \
+        d->dest++; \
         if (d->dict_ring) { d->dict_ring[d->dict_idx++] = c; if (d->dict_idx == d->dict_size) d->dict_idx = 0; } \
     }
 #endif // NO_DICT == 0
 #endif // !defined(TINF_PUT)
 
 #if NO_CB // NO_CB != 0
-#define uzlib_get_byte(d) (*(d)->source++)
+#define uzlib_get_byte(d) ALIGN_READ(d->source++)
 #else
 unsigned char TINFCC uzlib_get_byte(TINF_DATA *d);
 #endif

--- a/src/uzlib.h
+++ b/src/uzlib.h
@@ -111,6 +111,10 @@ struct uzlib_uncomp {
 #define ALIGN_WRITE(x,y) do { (*x) = (y); } while (0)
 #endif
 
+#ifndef ALIGN_READ_INC
+#define ALIGN_READ_INC(x) ({ __typeof__(*x) ret = ALIGN_READ(x); (x)++; ret; })
+#endif
+
 #ifndef TINF_PUT
 #if NO_DICT
 #define TINF_PUT(d, c) \
@@ -128,8 +132,9 @@ struct uzlib_uncomp {
 #endif // NO_DICT == 0
 #endif // !defined(TINF_PUT)
 
-#if NO_CB // NO_CB != 0
-#define uzlib_get_byte(d) ALIGN_READ(d->source++)
+#if NO_CB
+//#define uzlib_get_byte(d) ALIGN_READ(d->source++)
+#define uzlib_get_byte(d) ALIGN_READ_INC(d->source)
 #else
 unsigned char TINFCC uzlib_get_byte(TINF_DATA *d);
 #endif

--- a/src/uzlib.h
+++ b/src/uzlib.h
@@ -63,12 +63,14 @@ struct uzlib_uncomp {
     const unsigned char *source;
     /* Pointer to the next byte past the input buffer (source_limit = source + len) */
     const unsigned char *source_limit;
+#if !NO_CB
     /* If source_limit == NULL, or source >= source_limit, this function
        will be used to read next byte from source stream. The function may
        also return -1 in case of EOF (or irrecoverable error). Note that
        besides returning the next byte, it may also update source and
        source_limit fields, thus allowing for buffered operation. */
     int (*source_read_cb)(struct uzlib_uncomp *uncomp);
+#endif
 
     unsigned int tag;
     unsigned int bitcount;
@@ -101,18 +103,20 @@ struct uzlib_uncomp {
 
 #include "tinf_compat.h"
 
-#if NO_DICT
+#ifndef TINF_PUT
+#if NO_DICT // NO_DICT != 0
 #define TINF_PUT(d, c) \
     { \
         *d->dest++ = c; \
     }
-#else
+#else // NO_DICT == 0
 #define TINF_PUT(d, c) \
     { \
         *d->dest++ = c; \
         if (d->dict_ring) { d->dict_ring[d->dict_idx++] = c; if (d->dict_idx == d->dict_size) d->dict_idx = 0; } \
     }
-#endif
+#endif // NO_DICT == 0
+#endif // !defined(TINF_PUT)
 
 unsigned char TINFCC uzlib_get_byte(TINF_DATA *d);
 


### PR DESCRIPTION
From d-a-v:

> For the exact same purpose, I had initiated a similar job, FWIW, not proposed as pull-request. I implemented your idea through macros ALIGN_READ / ALIGN_WRITE that have default definitions for legacy behavior but that can be redefined to something else (reading from flash) when dictionary is disabled.
> This is a proof of concept that has been proposed nowhere, and proved to be working in an emulation environment only.
> 
> This functionality you propose would be indeed very useful on small targets.
> 
> This idea was abandoned because the esp8266 arduino OTA second stage happens at reboot time when there's still plenty/enough of temporary ram to be able to uncompress and reflash the FW. I'd like to thanks once again @pfalcon for this library. Credits are already given in the esp8266 arduino main readme.